### PR TITLE
fix(post-scan action)!: GCP Slack notification for FSS

### DIFF
--- a/post-scan-actions/gcp-python-slack-notification/README.md
+++ b/post-scan-actions/gcp-python-slack-notification/README.md
@@ -15,7 +15,7 @@
 
 ### LocalMachine
 
-1. Login to the Google cloud SDK
+1. Login to the Google Cloud SDK
 
    ```sh
    gcloud init

--- a/post-scan-actions/gcp-python-slack-notification/package-lock.json
+++ b/post-scan-actions/gcp-python-slack-notification/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloudone-fss-gcp-slack-notifications",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cloudone-fss-gcp-slack-notifications",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "serverless-google-cloudfunctions": "^4.6.0"

--- a/post-scan-actions/gcp-python-slack-notification/package.json
+++ b/post-scan-actions/gcp-python-slack-notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudone-fss-gcp-slack-notifications",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Slack notification post-scan action plugin for Cloud One File Storage Security",
   "main": "main.py",
   "scripts": {

--- a/post-scan-actions/gcp-python-slack-notification/serverless.yml
+++ b/post-scan-actions/gcp-python-slack-notification/serverless.yml
@@ -4,7 +4,7 @@ custom:
   defaultStage: prod
   stages:
     prod:
-      SLACK_URL: https://hooks.slack.com/services/<use-your-slack-url>
+      SLACK_URL: https://hooks.slack.com/services/T00000000/B00000000/<your-slack-url>
       SLACK_CHANNEL: notifications
       SLACK_USERNAME: Cloud One File Storage Security
       DEPLOYMENT_REGION: <gcp-deployment-region>
@@ -18,11 +18,6 @@ provider:
   runtime: python39
   region: ${self:custom.stages.${opt:stage, self:custom.defaultStage}.DEPLOYMENT_REGION}
   project: ${self:custom.stages.${opt:stage, self:custom.defaultStage}.GCP_PROJECT_ID}
-  # The GCF credentials can be a little tricky to set up. Luckily we've documented this for you here:
-  # https://serverless.com/framework/docs/providers/google/guide/credentials/
-  #
-  # the path to the credentials file needs to be absolute
-  # credentials: ~/Downloads/gcp-fss-03695d5bb5bf.json
   environment:
     SLACK_URL: ${self:custom.stages.${opt:stage, self:custom.defaultStage}.SLACK_URL}
     SLACK_CHANNEL: ${self:custom.stages.${opt:stage, self:custom.defaultStage}.SLACK_CHANNEL}


### PR DESCRIPTION
# Fix: GCP Slack notification for FSS

## Change Summary
- Cleaning up comments
- Using the Slack default URL
- Raising exception for non-200 HTTP responses

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
- Plugins that have versioning
  - [x] Version bumped and follows [Semantic Versioning](https://semver.org/)

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
